### PR TITLE
Verbose error message for wrong client & qr code counts

### DIFF
--- a/do.sh
+++ b/do.sh
@@ -56,8 +56,9 @@ done
 if ! ([[ $QR_CODE_COUNT -ge 0 ]] && [[ $QR_CODE_COUNT -le $CLIENTS ]])
 then
     echo "Incorrect value for argument -q!" 1>&2
+    echo "Number of QR codes should NOT be greater than number of client" 1>&2
+    echo "Given arguments: QR codes count $QR_CODE_COUNT, clients count $CLIENTS" 1>&2
     echo "" 1>&2
-
     usage
 fi
 


### PR DESCRIPTION
The implementation expects that the number of clients should be greater than or equals to number of qr codes.
But the only reason to understand it is to read the code.
Current error message for such case:
```shell
$ ./do.sh -c 1 -q 2
Incorrect value for argument -q!

Usage: ...
```

This pull requests is about making an error message more versose.
I've added this expectation (and processed argument values) to error text:
```shell
$ ./do.sh -c 1 -q 2
Incorrect value for argument -q!
Number of QR codes should NOT be greater than number of client
Given arguments: QR codes count 2, clients count 1
```
